### PR TITLE
Stub fields in Rails model generator

### DIFF
--- a/lib/generators/machinist/model/model_generator.rb
+++ b/lib/generators/machinist/model/model_generator.rb
@@ -4,7 +4,16 @@ module Machinist
       argument :attributes, :type => :array, :default => [], :banner => "field:type field:type"
 
       def create_blueprint
-        append_file "spec/support/blueprints.rb", "\n#{class_name}.blueprint do\n  # Attributes here\nend\n"
+        if attributes.empty?
+          fields = "  # Attributes here\n"
+        else
+          fields = ''
+          attributes.each do |a|
+            fields << "  #{a.name} { #{a.default.inspect} }\n"
+          end
+        end
+
+        append_file "spec/support/blueprints.rb", "\n#{class_name}.blueprint do\n#{fields}end\n"
       end
 
     end


### PR DESCRIPTION
Greetings Pete,

I've updated the Rails model generator to create some defaults for fields, like so:

```
$ rails g model Foo title:string date:datetime
...
$ cat spec/support/blueprints.rb 
require 'machinist/active_record'

# Add your blueprints here.
#
# e.g.
#   Post.blueprint do
#     title { "Post #{sn}" }
#     body  { "Lorem ipsum..." }
#   end

Foo.blueprint do
  title { "MyString" }
  date { "2010-10-09 16:44:25" }
end
```

Thanks for creating Machinist :-)
