### PR TITLE
Remove unnecessary Sequel refresh call in make

### DIFF
--- a/lib/machinist/sequel.rb
+++ b/lib/machinist/sequel.rb
@@ -37,7 +37,6 @@ module Machinist
         lathe = Lathe.run(Machinist::SequelAdapter, self.new, *args)
         unless Machinist.nerfed?
           lathe.object.save
-          lathe.object.refresh
         end
         lathe.object(&block)
       end

--- a/spec/sequel_spec.rb
+++ b/spec/sequel_spec.rb
@@ -57,6 +57,12 @@ module MachinistSequelSpecs
         person = Person.make
         person.should_not be_new
       end
+
+      it "should reload object after save with column default values" do
+        Person.blueprint { }
+        person = Person.make
+        person.admin.should == false
+      end
   
       it "should create and object through a many_to_one association" do
         Post.blueprint { }


### PR DESCRIPTION
Hi Pete

Sequel does a refresh by default for an inserted row, so there is no need for the explicit refresh in the Machinist adapter.

Thanks
Adam
