### PR TITLE
1.0 maintenance

### DIFF
--- a/lib/machinist/sequel.rb
+++ b/lib/machinist/sequel.rb
@@ -37,7 +37,6 @@ module Machinist
         lathe = Lathe.run(Machinist::SequelAdapter, self.new, *args)
         unless Machinist.nerfed?
           lathe.object.save
-          lathe.object.refresh
         end
         lathe.object(&block)
       end

--- a/lib/machinist/sequel.rb
+++ b/lib/machinist/sequel.rb
@@ -43,7 +43,7 @@ module Machinist
       end
 
       def make_unsaved(*args)
-        returning(Machinist.with_save_nerfed { make(*args) }) do |object|
+        (Machinist.with_save_nerfed { make(*args) }).tap do |object|
           yield object if block_given?
         end
       end


### PR DESCRIPTION
When I attempted to use the Sequel adaptor on Ruby 1.9.2 and Rails 3, I got some deprecation warnings about the use of returning in this one spot. I switched it to Object#tap, which I believe has been back-ported to 1.8.7. Is machinist 2 ready enough for me to use it instead? Thanks!
