### PR TITLE
Test::Unit support for 'rails generate model'

### DIFF
--- a/lib/generators/machinist/model/model_generator.rb
+++ b/lib/generators/machinist/model/model_generator.rb
@@ -1,12 +1,22 @@
 module Machinist
   module Generators #:nodoc:
     class ModelGenerator < Rails::Generators::NamedBase #:nodoc:
+      class_option :test_framework, :type => :string, :aliases => "-t", :desc => "Test framework to use Machinist with"
       argument :attributes, :type => :array, :default => [], :banner => "field:type field:type"
 
       def create_blueprint
-        append_file "spec/support/blueprints.rb", "\n#{class_name}.blueprint do\n  # Attributes here\nend\n"
+        append_file blueprints_path, "\n#{class_name}.blueprint do\n  # Attributes here\nend\n"
       end
 
+      protected
+
+      def blueprints_path
+        if options[:test_framework].to_sym == :rspec
+          "spec/support/blueprints.rb" 
+        else
+          "test/blueprints.rb"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Greetings, and thank you so much for such an excellent fixture replacement gem! I especially love the tight, painless integration between machinist and Rails 3.

One of my clients uses Test::Unit, and I discovered a small limitation when install machinist.

The existing install_generator supports both Test::Unit and RSpec,
but model_generator always assumes that our blueprints live in
spec/support/blueprints.rb.

This patch adds support for Test::Unit to model_generator.  Note that
there is now a small amount of code duplication between model_generator
and install_generator that should probably by factored out into a shared
module.

No unit tests are included, because I didn't see any tests for the existing generators, and I'm not quite sure how to set them up.

If you have any suggestions on rewriting this patch to either (1) include unit tests, or (2) factor out the shared generator code, please let me know. I'll be glad to make any changes you suggest.

Once again, many thanks for your excellent gem!
