### PR TITLE
Updated Titanous' DataMapper support to work on current 2.0 master

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--color
+--format documentation
+--backtrace

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,9 @@ gem "rake"
 gem "rcov"
 gem "rspec", ">= 2.0.0.beta.12"
 gem "jeweler"
+
+gem 'dm-core'
+gem 'dm-sqlite-adapter'
+gem 'dm-transactions'
+gem 'dm-migrations'
+gem 'dm-validations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,76 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activemodel (3.0.0)
+      activesupport (= 3.0.0)
+      builder (~> 2.1.2)
+      i18n (~> 0.4.1)
+    activerecord (3.0.0)
+      activemodel (= 3.0.0)
+      activesupport (= 3.0.0)
+      arel (~> 1.0.0)
+      tzinfo (~> 0.3.23)
+    activesupport (3.0.0)
+    addressable (2.2.0)
+    arel (1.0.1)
+      activesupport (~> 3.0.0)
+    builder (2.1.2)
+    data_objects (0.10.2)
+      addressable (~> 2.1)
+    diff-lcs (1.1.2)
+    dm-core (1.0.0)
+      addressable (~> 2.1)
+      extlib (~> 0.9.15)
+    dm-do-adapter (1.0.0)
+      data_objects (~> 0.10.1)
+      dm-core (~> 1.0.0)
+    dm-migrations (1.0.0)
+      dm-core (~> 1.0.0)
+    dm-sqlite-adapter (1.0.0)
+      dm-do-adapter (~> 1.0.0)
+      do_sqlite3 (~> 0.10.2)
+    dm-transactions (1.0.0)
+      dm-core (~> 1.0.0)
+    dm-validations (1.0.0)
+      dm-core (~> 1.0.0)
+    do_sqlite3 (0.10.2)
+      data_objects (= 0.10.2)
+    extlib (0.9.15)
+    gemcutter (0.6.1)
+    git (1.2.5)
+    i18n (0.4.1)
+    jeweler (1.4.0)
+      gemcutter (>= 0.1.0)
+      git (>= 1.2.5)
+      rubyforge (>= 2.0.0)
+    json_pure (1.4.6)
+    mysql (2.8.1)
+    rake (0.8.7)
+    rcov (0.9.8)
+    rspec (2.0.0.beta.20)
+      rspec-core (= 2.0.0.beta.20)
+      rspec-expectations (= 2.0.0.beta.20)
+      rspec-mocks (= 2.0.0.beta.20)
+    rspec-core (2.0.0.beta.20)
+    rspec-expectations (2.0.0.beta.20)
+      diff-lcs (>= 1.1.2)
+    rspec-mocks (2.0.0.beta.20)
+    rubyforge (2.0.4)
+      json_pure (>= 1.1.7)
+    tzinfo (0.3.23)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord
+  dm-core
+  dm-migrations
+  dm-sqlite-adapter
+  dm-transactions
+  dm-validations
+  jeweler
+  mysql
+  rake
+  rcov
+  rspec (>= 2.0.0.beta.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,5 +65,5 @@ DEPENDENCIES
   machinist!
   rake
   rcov
-  rspec (>= 2.0.0.beta.12)
+  rspec (~> 2.0)
   sqlite3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    machinist (2.0.0.beta2)
+    machinist (2.0.0.beta3)
 
 GEM
   remote: http://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,6 @@ GEM
     builder (2.1.2)
     diff-lcs (1.1.2)
     i18n (0.5.0)
-    mysql (2.8.1)
     rake (0.8.7)
     rcov (0.9.9)
     rspec (2.5.0)
@@ -31,6 +30,7 @@ GEM
     rspec-expectations (2.5.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.5.0)
+    sqlite3 (1.3.3)
     tzinfo (0.3.24)
 
 PLATFORMS
@@ -39,7 +39,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord
   machinist!
-  mysql
   rake
   rcov
   rspec (>= 2.0.0.beta.12)
+  sqlite3

--- a/lib/machinist/datamapper.rb
+++ b/lib/machinist/datamapper.rb
@@ -7,7 +7,11 @@ module Machinist::DataMapper
 
     def make!(attributes = {})
       object = make(attributes)
-      object.reload if object.save
+      if object.save
+        object.reload
+      else
+        raise ArgumentError, "Error creating object: #{ object.errors.full_messages.inspect }"
+      end
     end
 
     def box(object)

--- a/lib/machinist/datamapper.rb
+++ b/lib/machinist/datamapper.rb
@@ -1,54 +1,7 @@
 require 'dm-core'
 require 'machinist'
-
-module Machinist::DataMapper
-
-  class Blueprint < Machinist::Blueprint
-
-    def make!(attributes = {})
-      object = make(attributes)
-      if object.save
-        object.reload
-      else
-        raise SaveFailedError.new(object)
-      end
-    end
-
-    def box(object)
-      object.id
-    end
-
-    def unbox(id)
-      @class.get(id)
-    end
-
-    def outside_transaction
-      raise NotImplementedError, 'Disable object caching'
-    end
-
-    def lathe_class
-      Machinist::DataMapper::Lathe
-    end
-
-  end
-
-  class Lathe < Machinist::Lathe
-
-    def make_one_value(attribute, args)
-      if block_given?
-        raise_argument_error(attribute) unless args.empty?
-        yield
-      else # make an association
-        association = @klass.relationships[attribute.to_s]
-        raise_argument_error(attribute) unless association
-        association_klass = association.parent_model == @klass ? association.child_model : association.parent_model
-        association_klass.make(*args)
-      end
-    end
-
-  end
-
-end
+require 'machinist/datamapper/blueprint'
+require 'machinist/datamapper/lathe'
 
 module Machinist::DataMapper::Extension
   def blueprint_class

--- a/lib/machinist/datamapper.rb
+++ b/lib/machinist/datamapper.rb
@@ -10,7 +10,7 @@ module Machinist::DataMapper
       if object.save
         object.reload
       else
-        raise ArgumentError, "Error creating object: #{ object.errors.full_messages.inspect }"
+        raise SaveFailedError.new(object)
       end
     end
 

--- a/lib/machinist/datamapper.rb
+++ b/lib/machinist/datamapper.rb
@@ -1,0 +1,55 @@
+require 'dm-core'
+require 'machinist'
+
+module Machinist::DataMapper
+
+  class Blueprint < Machinist::Blueprint
+
+    def make!(attributes = {})
+      object = make(attributes)
+      object.reload if object.save
+    end
+
+    def box(object)
+      object.id
+    end
+
+    def unbox(id)
+      @class.get(id)
+    end
+
+    def outside_transaction
+      raise NotImplementedError, 'Disable object caching'
+    end
+
+    def lathe_class
+      Machinist::DataMapper::Lathe
+    end
+
+  end
+
+  class Lathe < Machinist::Lathe
+
+    def make_one_value(attribute, args)
+      if block_given?
+        raise_argument_error(attribute) unless args.empty?
+        yield
+      else # make an association
+        association = @klass.relationships[attribute.to_s]
+        raise_argument_error(attribute) unless association
+        association_klass = association.parent_model == @klass ? association.child_model : association.parent_model
+        association_klass.make(*args)
+      end
+    end
+
+  end
+
+end
+
+module Machinist::DataMapper::Extension
+  def blueprint_class
+    Machinist::DataMapper::Blueprint
+  end
+end
+
+DataMapper::Model.append_extensions(Machinist::Machinable, Machinist::DataMapper::Extension)

--- a/lib/machinist/datamapper/blueprint.rb
+++ b/lib/machinist/datamapper/blueprint.rb
@@ -1,0 +1,18 @@
+module Machinist::DataMapper
+  class Blueprint < Machinist::Blueprint
+
+    def make!(attributes = {})
+      object = make(attributes)
+      if object.save
+        object.reload
+      else
+        raise Machinist::SaveFailedError.new(object)
+      end
+    end
+
+    def lathe_class
+      Machinist::DataMapper::Lathe
+    end
+
+  end
+end

--- a/lib/machinist/datamapper/lathe.rb
+++ b/lib/machinist/datamapper/lathe.rb
@@ -1,0 +1,26 @@
+module Machinist::DataMapper
+
+  class Lathe < Machinist::Lathe
+
+    def make_one_value(attribute, args)
+      if block_given?
+        raise_argument_error(attribute) unless args.empty?
+        yield
+      else # make an association
+        make_association(attribute, args)
+      end
+    end
+
+    def make_association(attribute, args)
+      association = @klass.relationships[attribute.to_s]
+
+      if association
+        association.target_model.make(*args)
+      else
+        raise_argument_error(attribute)
+      end
+    end
+
+  end
+
+end

--- a/lib/machinist/exceptions.rb
+++ b/lib/machinist/exceptions.rb
@@ -2,6 +2,20 @@ module Machinist
 
   # Raised when make! is called on a class whose blueprints don't support
   # saving.
+  class SaveFailedError < RuntimeError
+    attr_reader :resource
+
+    def initialize(resource)
+      @resource = resource
+    end
+
+    def message
+      "Error saving resource: #{@resource}"
+    end
+  end
+
+  # Raised when make! is called on a class whose blueprints don't support
+  # saving.
   class BlueprintCantSaveError < RuntimeError
     attr_reader :blueprint
 

--- a/lib/machinist/exceptions.rb
+++ b/lib/machinist/exceptions.rb
@@ -10,7 +10,7 @@ module Machinist
     end
 
     def message
-      "Error saving resource: #{@resource}"
+      "Error saving resource: #{@resource}. Errors: #{@resource.errors.inspect}"
     end
   end
 

--- a/lib/machinist/machinable.rb
+++ b/lib/machinist/machinable.rb
@@ -2,6 +2,10 @@ module Machinist
 
   # Extend classes with this module to define the blueprint and make methods.
   module Machinable
+    def blueprints
+      @blueprints ||= {}
+    end
+
     # Define a blueprint with the given name for this class.
     #
     # e.g.
@@ -13,12 +17,11 @@ module Machinist
     # If you provide the +name+ argument, a named blueprint will be created.
     # See the +blueprint_name+ argument to the make method.
     def blueprint(name = :master, &block)
-      @blueprints ||= {}
       if block_given?
         parent = (name == :master ? superclass : self) # Where should we look for the parent blueprint?
-        @blueprints[name] = blueprint_class.new(self, :parent => parent, &block)
+        blueprints[name] = blueprint_class.new(self, :parent => parent, &block)
       end
-      @blueprints[name]
+      blueprints[name]
     end
 
     # Construct an object from a blueprint.
@@ -55,7 +58,7 @@ module Machinist
 
     # Remove all blueprints defined on this class.
     def clear_blueprints!
-      @blueprints = {}
+      blueprints.clear
     end
 
     # Classes that include Machinable can override this method if they want to
@@ -80,9 +83,7 @@ module Machinist
       attributes = shift_arg[Hash]   || {}
       raise ArgumentError.new("Couldn't understand arguments") unless args.empty?
 
-      @blueprints ||= {}
-      blueprint = @blueprints[name]
-      raise NoBlueprintError.new(self, name) unless blueprint
+      blueprint = blueprints[name] or raise NoBlueprintError.new(self, name)
 
       if count.nil?
         yield(blueprint, attributes)

--- a/lib/machinist/version.rb
+++ b/lib/machinist/version.rb
@@ -1,3 +1,3 @@
 module Machinist
-  VERSION = "2.0.0.beta2"
+  VERSION = "2.0.0.beta3"
 end

--- a/machinist.gemspec
+++ b/machinist.gemspec
@@ -9,14 +9,16 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
   s.authors = ["Pete Yandell"]
-  s.date = %q{2010-07-07}
+  s.date = %q{2010-09-04}
   s.email = %q{pete@notahat.com}
   s.extra_rdoc_files = [
     "README.markdown"
   ]
   s.files = [
     ".gitignore",
+     ".rspec",
      "Gemfile",
+     "Gemfile.lock",
      "MIT-LICENSE",
      "README.markdown",
      "Rakefile",
@@ -32,6 +34,7 @@ Gem::Specification.new do |s|
      "lib/machinist/active_record/lathe.rb",
      "lib/machinist/blueprint.rb",
      "lib/machinist/configuration.rb",
+     "lib/machinist/datamapper.rb",
      "lib/machinist/exceptions.rb",
      "lib/machinist/lathe.rb",
      "lib/machinist/machinable.rb",
@@ -40,12 +43,14 @@ Gem::Specification.new do |s|
      "machinist.gemspec",
      "spec/active_record_spec.rb",
      "spec/blueprint_spec.rb",
+     "spec/datamapper_spec.rb",
      "spec/exceptions_spec.rb",
      "spec/inheritance_spec.rb",
      "spec/machinable_spec.rb",
      "spec/shop_spec.rb",
      "spec/spec_helper.rb",
      "spec/support/active_record_environment.rb",
+     "spec/support/datamapper_environment.rb",
      "spec/warehouse_spec.rb"
   ]
   s.homepage = %q{http://github.com/notahat/machinist}
@@ -56,12 +61,14 @@ Gem::Specification.new do |s|
   s.test_files = [
     "spec/active_record_spec.rb",
      "spec/blueprint_spec.rb",
+     "spec/datamapper_spec.rb",
      "spec/exceptions_spec.rb",
      "spec/inheritance_spec.rb",
      "spec/machinable_spec.rb",
      "spec/shop_spec.rb",
      "spec/spec_helper.rb",
      "spec/support/active_record_environment.rb",
+     "spec/support/datamapper_environment.rb",
      "spec/warehouse_spec.rb"
   ]
 

--- a/machinist.gemspec
+++ b/machinist.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "activerecord"
-  s.add_development_dependency "mysql"
+  s.add_development_dependency "sqlite3"
   s.add_development_dependency "rake"
   s.add_development_dependency "rcov"
   s.add_development_dependency "rspec", ">= 2.0.0.beta.12"

--- a/machinist.gemspec
+++ b/machinist.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rake"
   s.add_development_dependency "rcov"
-  s.add_development_dependency "rspec", ">= 2.0.0.beta.12"
+  s.add_development_dependency "rspec", "~>2.0"
 
   dm_version = "~>1.1.0"
   s.add_development_dependency 'dm-core',           dm_version

--- a/spec/active_record_spec.rb
+++ b/spec/active_record_spec.rb
@@ -3,6 +3,7 @@ require 'support/active_record_environment'
 
 describe Machinist::ActiveRecord do
   include ActiveRecordEnvironment
+  AR = ActiveRecordEnvironment
 
   before(:each) do
     empty_database!
@@ -10,87 +11,87 @@ describe Machinist::ActiveRecord do
 
   context "make" do
     it "should return an unsaved object" do
-      Post.blueprint { }
-      post = Post.make
-      post.should be_a(Post)
+      AR::Post.blueprint { }
+      post = AR::Post.make
+      post.should be_a(AR::Post)
       post.should be_new_record
     end
   end
 
   context "make!" do
     it "should make and save objects" do
-      Post.blueprint { }
-      post = Post.make!
-      post.should be_a(Post)
+      AR::Post.blueprint { }
+      post = AR::Post.make!
+      post.should be_a(AR::Post)
       post.should_not be_new_record
     end
 
     it "should raise an exception for an invalid object" do
-      User.blueprint { }
+      AR::User.blueprint { }
       lambda {
-        User.make!(:username => "")
+        AR::User.make!(:username => "")
       }.should raise_error(ActiveRecord::RecordInvalid)
     end
   end
 
   context "associations support" do
     it "should handle belongs_to associations" do
-      User.blueprint do
+      AR::User.blueprint do
         username { "user_#{sn}" }
       end
-      Post.blueprint do
+      AR::Post.blueprint do
         author
       end
-      post = Post.make!
-      post.should be_a(Post)
+      post = AR::Post.make!
+      post.should be_a(AR::Post)
       post.should_not be_new_record
-      post.author.should be_a(User)
+      post.author.should be_a(AR::User)
       post.author.should_not be_new_record
     end
 
     it "should handle has_many associations" do
-      Post.blueprint do
+      AR::Post.blueprint do
         comments(3)
       end
-      Comment.blueprint { }
-      post = Post.make!
-      post.should be_a(Post)
+      AR::Comment.blueprint { }
+      post = AR::Post.make!
+      post.should be_a(AR::Post)
       post.should_not be_new_record
       post.should have(3).comments
       post.comments.each do |comment|
-        comment.should be_a(Comment)
+        comment.should be_a(AR::Comment)
         comment.should_not be_new_record
       end
     end
 
     it "should handle habtm associations" do
-      Post.blueprint do
+      AR::Post.blueprint do
         tags(3)
       end
-      Tag.blueprint do
+      AR::Tag.blueprint do
         name { "tag_#{sn}" }
       end
-      post = Post.make!
-      post.should be_a(Post)
+      post = AR::Post.make!
+      post.should be_a(AR::Post)
       post.should_not be_new_record
       post.should have(3).tags
       post.tags.each do |tag|
-        tag.should be_a(Tag)
+        tag.should be_a(AR::Tag)
         tag.should_not be_new_record
       end
     end
 
     it "should handle overriding associations" do
-      User.blueprint do
+      AR::User.blueprint do
         username { "user_#{sn}" }
       end
-      Post.blueprint do
-        author { User.make!(:username => "post_author_#{sn}") }
+      AR::Post.blueprint do
+        author { AR::User.make!(:username => "post_author_#{sn}") }
       end
-      post = Post.make!
-      post.should be_a(Post)
+      post = AR::Post.make!
+      post.should be_a(AR::Post)
       post.should_not be_new_record
-      post.author.should be_a(User)
+      post.author.should be_a(AR::User)
       post.author.should_not be_new_record
       post.author.username.should =~ /^post_author_\d+$/
     end
@@ -98,9 +99,9 @@ describe Machinist::ActiveRecord do
 
   context "error handling" do
     it "should raise an exception for an attribute with no value" do
-      User.blueprint { username }
+      AR::User.blueprint { username }
       lambda {
-        User.make
+        AR::User.make
       }.should raise_error(ArgumentError)
     end
   end

--- a/spec/datamapper_spec.rb
+++ b/spec/datamapper_spec.rb
@@ -35,7 +35,7 @@ describe Machinist::DataMapper do
 
     it "should not save an invalid object" do
       DM::User.blueprint { }
-      DM::User.make!(:username => "").should be_false
+      expect { DM::User.make!(:username => "") }.to raise_error
     end
 
     #Currently not implemented
@@ -53,7 +53,7 @@ describe Machinist::DataMapper do
       #fake_a_test { post_a = DM::Post.make! }
       #fake_a_test { post_b = DM::Post.make! }
       #post_a.should_not == post_b
-      #Machinist.configuration.cache_objects = true 
+      #Machinist.configuration.cache_objects = true
     #end
   end
 

--- a/spec/datamapper_spec.rb
+++ b/spec/datamapper_spec.rb
@@ -1,0 +1,134 @@
+require File.dirname(__FILE__) + '/spec_helper'
+require 'support/datamapper_environment'
+
+describe Machinist::DataMapper do
+  include DM
+
+  before(:each) do
+    Machinist.configuration.cache_objects = false # not implemented
+    Machinist::Shop.instance.reset!
+    empty_database!
+  end
+
+  def fake_a_test
+    t = DataMapper::Transaction.new
+    t.begin
+    Machinist.reset_before_test
+    yield
+    t.rollback
+  end
+
+  context "make" do
+    it "should return an unsaved object" do
+      DM::Post.blueprint { }
+      post = DM::Post.make
+      post.should be_a(DM::Post)
+      post.should be_new_record
+    end
+  end
+
+  context "make!" do
+    it "should make and save objects" do
+      DM::Post.blueprint { }
+      post = DM::Post.make!
+      post.should be_a(DM::Post)
+      post.should_not be_new_record
+    end
+
+    it "should not save an invalid object" do
+      DM::User.blueprint { }
+      DM::User.make!(:username => "").should be_false
+    end
+
+    #Currently not implemented
+    #it "should buy objects from the shop" do
+      #DM::Post.blueprint { }
+      #post_a, post_b = nil, nil
+      #fake_a_test { post_a = DM::Post.make! }
+      #fake_a_test { post_b = DM::Post.make! }
+      #post_a.should == post_b
+    #end
+
+    #it "should not buy objects from the shop if caching is disabled" do
+      #DM::Post.blueprint { }
+      #post_a, post_b = nil, nil
+      #fake_a_test { post_a = DM::Post.make! }
+      #fake_a_test { post_b = DM::Post.make! }
+      #post_a.should_not == post_b
+      #Machinist.configuration.cache_objects = true 
+    #end
+  end
+
+  context "associations support" do
+    it "should handle belongs_to associations" do
+      DM::User.blueprint do
+        username { "user_#{sn}" }
+      end
+      DM::Post.blueprint do
+        author
+      end
+      post = DM::Post.make!
+      post.should be_a(DM::Post)
+      post.should_not be_new_record
+      post.author.should be_a(DM::User)
+      post.author.should_not be_new_record
+    end
+
+    it "should handle has_many associations" do
+      DM::Post.blueprint do
+        comments(3)
+      end
+      DM::Comment.blueprint { }
+      post = DM::Post.make!
+      post.should be_a(DM::Post)
+      post.should_not be_new_record
+      post.should have(3).comments
+      post.comments.each do |comment|
+        comment.should be_a(DM::Comment)
+        comment.should_not be_new_record
+      end
+    end
+
+    it "should handle habtm associations" do
+      DM::Post.blueprint do
+        tags(3)
+      end
+      DM::Tag.blueprint do
+        name { "tag_#{sn}" }
+      end
+      post = DM::Post.make!
+      post.should be_a(DM::Post)
+      post.should_not be_new_record
+      post.should have(3).tags
+      post.tags.each do |tag|
+        tag.should be_a(DM::Tag)
+        tag.should_not be_new_record
+      end
+    end
+
+    it "should handle overriding associations" do
+      DM::User.blueprint do
+        username { "user_#{sn}" }
+      end
+      DM::Post.blueprint do
+        author { DM::User.make!(:username => "post_author_#{sn}") }
+      end
+      post = DM::Post.make!
+      post.should be_a(DM::Post)
+      post.should_not be_new_record
+      post.author.should be_a(DM::User)
+      post.author.should_not be_new_record
+      post.author.username.should =~ /^post_author_\d+$/
+    end
+  end
+
+  context "error handling" do
+    it "should raise an exception for an attribute with no value" do
+      DM::User.blueprint { username }
+      lambda {
+        DM::User.make
+      }.should raise_error(ArgumentError)
+    end
+  end
+
+end

--- a/spec/datamapper_spec.rb
+++ b/spec/datamapper_spec.rb
@@ -123,9 +123,7 @@ describe Machinist::DataMapper do
   context "error handling" do
     it "should raise an exception for an attribute with no value" do
       DM::User.blueprint { username }
-      lambda {
-        DM::User.make
-      }.should raise_error(ArgumentError)
+      expect { DM::User.make }.to raise_error(SaveFailedError)
     end
   end
 

--- a/spec/datamapper_spec.rb
+++ b/spec/datamapper_spec.rb
@@ -123,7 +123,12 @@ describe Machinist::DataMapper do
   context "error handling" do
     it "should raise an exception for an attribute with no value" do
       DM::User.blueprint { username }
-      expect { DM::User.make }.to raise_error(SaveFailedError)
+      expect { DM::User.make }.to raise_error(ArgumentError)
+    end
+
+    it "should raise a SaveFailedError exception when given an invalid attribute value" do
+      DM::User.blueprint { username { "" } }
+      expect { DM::User.make! }.to raise_error(Machinist::SaveFailedError)
     end
   end
 

--- a/spec/support/active_record_environment.rb
+++ b/spec/support/active_record_environment.rb
@@ -32,26 +32,27 @@ ActiveRecord::Schema.define(:version => 0) do
   end
 end
 
-class User < ActiveRecord::Base
-  validates_presence_of :username
-  validates_uniqueness_of :username
-end
-
-class Post < ActiveRecord::Base
-  has_many :comments
-  belongs_to :author, :class_name => "User"
-  has_and_belongs_to_many :tags
-end
-
-class Comment < ActiveRecord::Base
-  belongs_to :post
-end
-
-class Tag < ActiveRecord::Base
-  has_and_belongs_to_many :posts
-end
-
 module ActiveRecordEnvironment
+
+  class User < ActiveRecord::Base
+    validates_presence_of :username
+    validates_uniqueness_of :username
+  end
+
+  class Post < ActiveRecord::Base
+    has_many :comments
+    belongs_to :author, :class_name => "User"
+    has_and_belongs_to_many :tags
+  end
+
+  class Comment < ActiveRecord::Base
+    belongs_to :post
+  end
+
+  class Tag < ActiveRecord::Base
+    has_and_belongs_to_many :posts
+  end
+
 
   def empty_database!
     [User, Post, Comment].each do |klass|

--- a/spec/support/active_record_environment.rb
+++ b/spec/support/active_record_environment.rb
@@ -2,10 +2,8 @@ require 'active_record'
 require 'machinist/active_record'
 
 ActiveRecord::Base.establish_connection(
-  :adapter  => "mysql",
-  :database => "machinist",
-  :username => "root",
-  :password => ""
+  :adapter  => "sqlite3",
+  :database => ":memory:"
 )
 
 ActiveRecord::Schema.define(:version => 0) do

--- a/spec/support/datamapper_environment.rb
+++ b/spec/support/datamapper_environment.rb
@@ -1,0 +1,55 @@
+require 'dm-core'
+require 'dm-migrations'
+require 'dm-validations'
+require 'dm-transactions'
+require 'machinist/datamapper'
+
+DataMapper.setup(:default, 'sqlite::memory:')
+
+module DM
+
+  class User
+    include DataMapper::Resource
+
+    property :id, Serial
+    property :username, String, :required => true, :unique => true
+  end
+
+  class Post
+    include DataMapper::Resource
+
+    property :id, Serial
+    property :author_id, Integer
+    property :body, Text
+
+    belongs_to :author, 'User'
+    has n, :comments
+    has n, :tags, :through => Resource
+  end
+
+  class Comment
+    include DataMapper::Resource
+
+    property :id, Serial
+    property :body, Text
+
+    belongs_to :post
+  end
+
+  class Tag
+    include DataMapper::Resource
+
+    property :id, Serial
+    property :name, String
+
+    has n, :posts, :through => Resource
+  end
+
+  def empty_database!
+    DataMapper.auto_migrate!
+    [User, Post, Comment].each do |klass|
+      klass.clear_blueprints!
+    end
+  end
+
+end


### PR DESCRIPTION
Hi,

I've updated @titanous fork which implements DataMapper support. I issued a pull request to @titanous, but haven't heard anything back (it's been a while), so I'm offering these changes directly back to you.

On top of the DataMapper support, I switch the default testing DB from MySQL to SQLite so that tests can be run with no external dependencies.

Finally, I moved the ActiveRecord models in the specs into an `AR` module, for clarity and to ensure no collisions with models from other ORMs (the DataMapper spec models are namespaced in a `DM` module). 

Thanks for Machinist!
