### PR TITLE
Fixes a deprecation warning from DataMapper 1.1.0 (latest)

### DIFF
--- a/lib/machinist/data_mapper.rb
+++ b/lib/machinist/data_mapper.rb
@@ -6,7 +6,7 @@ module Machinist
 
   class DataMapperAdapter
     def self.has_association?(object, attribute)
-      object.class.relationships.has_key?(attribute)
+      object.class.relationships.named?(attribute)
     end
 
     def self.class_for_association(object, attribute)


### PR DESCRIPTION
Specs were producing a lot of warnings like this:

```
DataMapper::RelationshipSet#has_key? is deprecated. Use DataMapper::RelationshipSet#named? instead: /usr/local/rvm/gems/ruby-1.9.2-p180/gems/machinist-1.0.6/lib/machinist/data_mapper.rb:9:in `has_association?'
DataMapper::RelationshipSet#has_key? is deprecated. Use DataMapper::RelationshipSet#named? instead: /usr/local/rvm/gems/ruby-1.9.2-p180/gems/machinist-1.0.6/lib/machinist/data_mapper.rb:9:in `has_association?'
DataMapper::RelationshipSet#has_key? is deprecated. Use DataMapper::RelationshipSet#named? instead: /usr/local/rvm/gems/ruby-1.9.2-p180/gems/machinist-1.0.6/lib/machinist/data_mapper.rb:9:in `has_association?'
DataMapper::RelationshipSet#has_key? is deprecated. Use DataMapper::RelationshipSet#named? instead: /usr/local/rvm/gems/ruby-1.9.2-p180/gems/machinist-1.0.6/lib/machinist/data_mapper.rb:9:in `has_association?'
DataMapper::RelationshipSet#has_key? is deprecated. Use DataMapper::RelationshipSet#named? instead: /usr/local/rvm/gems/ruby-1.9.2-p180/gems/machinist-1.0.6/lib/machinist/data_mapper.rb:9:in `has_association?'
DataMapper::RelationshipSet#has_key? is deprecated. Use DataMapper::RelationshipSet#named? instead: /usr/local/rvm/gems/ruby-1.9.2-p180/gems/machinist-1.0.6/lib/machinist/data_mapper.rb:9:in `has_association?'
```

This fixes that.  On a side note, has anyone expressed interest in adding DataMapper support to Machinist 2?  If you need a hand, I'm happy to look at it.
