### PR TITLE
DataMapper (>= 1.1.0, and possibly earlier?) support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,11 +19,23 @@ GEM
     addressable (2.2.6)
     arel (2.0.8)
     builder (2.1.2)
+    data_objects (0.10.6)
+      addressable (~> 2.1)
     diff-lcs (1.1.2)
     dm-core (1.1.0)
       addressable (~> 2.2.4)
+    dm-do-adapter (1.1.0)
+      data_objects (~> 0.10.2)
+      dm-core (~> 1.1.0)
+    dm-migrations (1.1.0)
+      dm-core (~> 1.1.0)
+    dm-mysql-adapter (1.1.0)
+      dm-do-adapter (~> 1.1.0)
+      do_mysql (~> 0.10.2)
     dm-validations (1.1.0)
       dm-core (~> 1.1.0)
+    do_mysql (0.10.6)
+      data_objects (= 0.10.6)
     i18n (0.5.0)
     mysql (2.8.1)
     rake (0.8.7)
@@ -44,6 +56,8 @@ PLATFORMS
 DEPENDENCIES
   activerecord
   dm-core
+  dm-migrations
+  dm-mysql-adapter
   dm-validations
   machinist!
   mysql

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,9 +16,14 @@ GEM
       arel (~> 2.0.2)
       tzinfo (~> 0.3.23)
     activesupport (3.0.4)
+    addressable (2.2.6)
     arel (2.0.8)
     builder (2.1.2)
     diff-lcs (1.1.2)
+    dm-core (1.1.0)
+      addressable (~> 2.2.4)
+    dm-validations (1.1.0)
+      dm-core (~> 1.1.0)
     i18n (0.5.0)
     mysql (2.8.1)
     rake (0.8.7)
@@ -38,6 +43,8 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord
+  dm-core
+  dm-validations
   machinist!
   mysql
   rake

--- a/lib/machinist/data_mapper.rb
+++ b/lib/machinist/data_mapper.rb
@@ -6,7 +6,7 @@ require 'machinist/data_mapper/lathe'
 module Machinist::DataMapper
   module BlueprintExtension
     def blueprint_class
-	    Machinist::DataMapper::Blueprint
+      Machinist::DataMapper::Blueprint
     end
   end 
 end

--- a/lib/machinist/data_mapper.rb
+++ b/lib/machinist/data_mapper.rb
@@ -4,11 +4,11 @@ require 'machinist/data_mapper/blueprint'
 require 'machinist/data_mapper/lathe'
 
 module Machinist::DataMapper
-	module BlueprintExtension
-	  def blueprint_class
+  module BlueprintExtension
+    def blueprint_class
 	    Machinist::DataMapper::Blueprint
-	  end
-	end 
+    end
+  end 
 end
 
 DataMapper::Model.append_extensions(Machinist::Machinable, Machinist::DataMapper::BlueprintExtension)

--- a/lib/machinist/data_mapper.rb
+++ b/lib/machinist/data_mapper.rb
@@ -1,0 +1,22 @@
+require 'dm-core'
+require 'machinist'
+require 'machinist/data_mapper/blueprint'
+require 'machinist/data_mapper/lathe'
+
+module DataMapper::Resource #:nodoc:
+  # FIXME: Maybe there's a better way to override the mixin post-include logic?
+  class << self
+    alias_method :old_included, :included
+    
+    def included(resource)
+      old_included(resource)
+      resource.extend Machinist::Machinable
+      
+      class << resource
+        def blueprint_class
+          Machinist::DataMapper::Blueprint
+        end
+      end
+    end
+  end
+end

--- a/lib/machinist/data_mapper.rb
+++ b/lib/machinist/data_mapper.rb
@@ -3,20 +3,12 @@ require 'machinist'
 require 'machinist/data_mapper/blueprint'
 require 'machinist/data_mapper/lathe'
 
-module DataMapper::Resource #:nodoc:
-  # FIXME: Maybe there's a better way to override the mixin post-include logic?
-  class << self
-    alias_method :old_included, :included
-    
-    def included(resource)
-      old_included(resource)
-      resource.extend Machinist::Machinable
-      
-      class << resource
-        def blueprint_class
-          Machinist::DataMapper::Blueprint
-        end
-      end
-    end
-  end
+module Machinist::DataMapper
+	module BlueprintExtension
+	  def blueprint_class
+	    Machinist::DataMapper::Blueprint
+	  end
+	end 
 end
+
+DataMapper::Model.append_extensions(Machinist::Machinable, Machinist::DataMapper::BlueprintExtension)

--- a/lib/machinist/data_mapper/blueprint.rb
+++ b/lib/machinist/data_mapper/blueprint.rb
@@ -4,7 +4,7 @@ module Machinist::DataMapper
     def make!(attributes = {})
       object = make(attributes)
       object.raise_on_save_failure = true
-      object.save && object
+      object.save && object.reload
     end
 
     def lathe_class #:nodoc:

--- a/lib/machinist/data_mapper/blueprint.rb
+++ b/lib/machinist/data_mapper/blueprint.rb
@@ -1,0 +1,13 @@
+module Machinist::DataMapper
+  class Blueprint < Machinist::Blueprint
+    # Make and save an object.
+    def make!(attributes = {})
+      object = make(attributes)
+      object.save && object
+    end
+
+    def lathe_class #:nodoc:
+      Machinist::DataMapper::Lathe
+    end
+  end
+end

--- a/lib/machinist/data_mapper/blueprint.rb
+++ b/lib/machinist/data_mapper/blueprint.rb
@@ -3,6 +3,7 @@ module Machinist::DataMapper
     # Make and save an object.
     def make!(attributes = {})
       object = make(attributes)
+      object.raise_on_save_failure = true
       object.save && object
     end
 

--- a/lib/machinist/data_mapper/lathe.rb
+++ b/lib/machinist/data_mapper/lathe.rb
@@ -1,0 +1,24 @@
+module Machinist::DataMapper
+
+  class Lathe < Machinist::Lathe
+
+    def make_one_value(attribute, args) #:nodoc:
+      if block_given?
+        raise_argument_error(attribute) unless args.empty?
+        yield
+      else
+        make_association(attribute, args)
+      end
+    end
+
+    def make_association(attribute, args) #:nodoc:
+      association = @klass.relationships[attribute]
+      if association
+        association.target_model.make(*args)
+      else
+        raise_argument_error(attribute)
+      end
+    end
+
+  end
+end

--- a/machinist.gemspec
+++ b/machinist.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "activerecord"
   s.add_development_dependency "dm-core"
   s.add_development_dependency "dm-validations"
+  s.add_development_dependency "dm-migrations"
+  s.add_development_dependency "dm-mysql-adapter"
   s.add_development_dependency "mysql"
   s.add_development_dependency "rake"
   s.add_development_dependency "rcov"

--- a/machinist.gemspec
+++ b/machinist.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "activerecord"
+  s.add_development_dependency "dm-core"
+  s.add_development_dependency "dm-validations"
   s.add_development_dependency "mysql"
   s.add_development_dependency "rake"
   s.add_development_dependency "rcov"

--- a/spec/active_record_spec.rb
+++ b/spec/active_record_spec.rb
@@ -2,95 +2,95 @@ require File.dirname(__FILE__) + '/spec_helper'
 require 'support/active_record_environment'
 
 describe Machinist::ActiveRecord do
-  include ActiveRecordEnvironment
+  AR = ActiveRecordEnvironment
 
   before(:each) do
-    empty_database!
+    ActiveRecordEnvironment.empty_database!
   end
 
   context "make" do
     it "should return an unsaved object" do
-      Post.blueprint { }
-      post = Post.make
-      post.should be_a(Post)
+      AR::Post.blueprint { }
+      post = AR::Post.make
+      post.should be_a(AR::Post)
       post.should be_new_record
     end
   end
 
   context "make!" do
     it "should make and save objects" do
-      Post.blueprint { }
-      post = Post.make!
-      post.should be_a(Post)
+      AR::Post.blueprint { }
+      post = AR::Post.make!
+      post.should be_a(AR::Post)
       post.should_not be_new_record
     end
 
     it "should raise an exception for an invalid object" do
-      User.blueprint { }
+      AR::User.blueprint { }
       lambda {
-        User.make!(:username => "")
+        AR::User.make!(:username => "")
       }.should raise_error(ActiveRecord::RecordInvalid)
     end
   end
 
   context "associations support" do
     it "should handle belongs_to associations" do
-      User.blueprint do
+      AR::User.blueprint do
         username { "user_#{sn}" }
       end
-      Post.blueprint do
+      AR::Post.blueprint do
         author
       end
-      post = Post.make!
-      post.should be_a(Post)
+      post = AR::Post.make!
+      post.should be_a(AR::Post)
       post.should_not be_new_record
-      post.author.should be_a(User)
+      post.author.should be_a(AR::User)
       post.author.should_not be_new_record
     end
 
     it "should handle has_many associations" do
-      Post.blueprint do
+      AR::Post.blueprint do
         comments(3)
       end
-      Comment.blueprint { }
-      post = Post.make!
-      post.should be_a(Post)
+      AR::Comment.blueprint { }
+      post = AR::Post.make!
+      post.should be_a(AR::Post)
       post.should_not be_new_record
       post.should have(3).comments
       post.comments.each do |comment|
-        comment.should be_a(Comment)
+        comment.should be_a(AR::Comment)
         comment.should_not be_new_record
       end
     end
 
     it "should handle habtm associations" do
-      Post.blueprint do
+      AR::Post.blueprint do
         tags(3)
       end
-      Tag.blueprint do
+      AR::Tag.blueprint do
         name { "tag_#{sn}" }
       end
-      post = Post.make!
-      post.should be_a(Post)
+      post = AR::Post.make!
+      post.should be_a(AR::Post)
       post.should_not be_new_record
       post.should have(3).tags
       post.tags.each do |tag|
-        tag.should be_a(Tag)
+        tag.should be_a(AR::Tag)
         tag.should_not be_new_record
       end
     end
 
     it "should handle overriding associations" do
-      User.blueprint do
+      AR::User.blueprint do
         username { "user_#{sn}" }
       end
-      Post.blueprint do
-        author { User.make!(:username => "post_author_#{sn}") }
+      AR::Post.blueprint do
+        author { AR::User.make!(:username => "post_author_#{sn}") }
       end
-      post = Post.make!
-      post.should be_a(Post)
+      post = AR::Post.make!
+      post.should be_a(AR::Post)
       post.should_not be_new_record
-      post.author.should be_a(User)
+      post.author.should be_a(AR::User)
       post.author.should_not be_new_record
       post.author.username.should =~ /^post_author_\d+$/
     end
@@ -98,9 +98,9 @@ describe Machinist::ActiveRecord do
 
   context "error handling" do
     it "should raise an exception for an attribute with no value" do
-      User.blueprint { username }
+      AR::User.blueprint { username }
       lambda {
-        User.make
+        AR::User.make
       }.should raise_error(ArgumentError)
     end
   end

--- a/spec/data_mapper_spec.rb
+++ b/spec/data_mapper_spec.rb
@@ -25,15 +25,11 @@ describe Machinist::DataMapper do
       post.should_not be_new
     end
 
-    # FIXME: The AR version expects an Exception. Since DM doesn't have that behaviour
-    # by default, I'm asserting the DM behaviour here.
-    # It is possible to force validation errors to manifest as Exceptions, but that would
-    # alter application behaviour.  If we really want Exceptions, which I suspect we do,
-    # since we want our tests to fail, I'll come back and just manually raise the Exception
-    # when #save returns false, rather than pushing that responsibilty onto DM.
-    it "should return false for an invalid object" do
+    it "should raise an exception for an invalid object" do
       User.blueprint { }
-      User.make!(:username => "").should be_false
+      lambda {
+        User.make!(:username => "")
+      }.should raise_error(DataMapper::SaveFailureError)
     end
   end
   

--- a/spec/data_mapper_spec.rb
+++ b/spec/data_mapper_spec.rb
@@ -1,0 +1,111 @@
+require File.dirname(__FILE__) + '/spec_helper'
+require 'support/data_mapper_environment'
+
+describe Machinist::DataMapper do
+  include DataMapperEnvironment
+
+  before(:each) do
+    purge_models!
+  end
+  
+  context "make" do
+    it "should return an unsaved object" do
+      Post.blueprint { }
+      post = Post.make
+      post.should be_a(Post)
+      post.should be_new
+    end
+  end
+  
+  context "make!" do
+    it "should make and save objects" do
+      Post.blueprint { }
+      post = Post.make!
+      post.should be_a(Post)
+      post.should_not be_new
+    end
+
+    # FIXME: The AR version expects an Exception. Since DM doesn't have that behaviour
+    # by default, I'm asserting the DM behaviour here.
+    # It is possible to force validation errors to manifest as Exceptions, but that would
+    # alter application behaviour.  If we really want Exceptions, which I suspect we do,
+    # since we want our tests to fail, I'll come back and just manually raise the Exception
+    # when #save returns false, rather than pushing that responsibilty onto DM.
+    it "should return false for an invalid object" do
+      User.blueprint { }
+      User.make!(:username => "").should be_false
+    end
+  end
+  
+  context "associations support" do
+    it "should handle belongs_to associations" do
+      User.blueprint do
+        username { "user_#{sn}" }
+      end
+      Post.blueprint do
+        author
+      end
+      post = Post.make!
+      post.should be_a(Post)
+      post.should_not be_new
+      post.author.should be_a(User)
+      post.author.should_not be_new
+    end
+    
+    it "should handle has_many associations" do
+      Post.blueprint do
+        comments(3)
+      end
+      Comment.blueprint { }
+      post = Post.make!
+      post.should be_a(Post)
+      post.should_not be_new
+      post.should have(3).comments
+      post.comments.each do |comment|
+        comment.should be_a(Comment)
+        comment.should_not be_new
+      end
+    end
+    
+    it "should handle habtm associations" do
+      Post.blueprint do
+        tags(3)
+      end
+      Tag.blueprint do
+        name { "tag_#{sn}" }
+      end
+      post = Post.make!
+      post.should be_a(Post)
+      post.should_not be_new
+      post.should have(3).tags
+      post.tags.each do |tag|
+        tag.should be_a(Tag)
+        tag.should_not be_new
+      end
+    end
+    
+    it "should handle overriding associations" do
+      User.blueprint do
+        username { "user_#{sn}" }
+      end
+      Post.blueprint do
+        author { DataMapperEnvironment::User.make!(:username => "post_author_#{sn}") }
+      end
+      post = Post.make!
+      post.should be_a(Post)
+      post.should_not be_new
+      post.author.should be_a(User)
+      post.author.should_not be_new
+      post.author.username.should =~ /^post_author_\d+$/
+    end
+  end
+  
+  context "error handling" do
+    it "should raise an exception for an attribute with no value" do
+      User.blueprint { username }
+      lambda {
+        User.make
+      }.should raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/data_mapper_spec.rb
+++ b/spec/data_mapper_spec.rb
@@ -2,95 +2,94 @@ require File.dirname(__FILE__) + '/spec_helper'
 require 'support/data_mapper_environment'
 
 describe Machinist::DataMapper do
-  include DataMapperEnvironment
+  DM = DataMapperEnvironment
 
   before(:each) do
-    purge_models!
+    DataMapperEnvironment.empty_database!
   end
-  
+
   context "make" do
     it "should return an unsaved object" do
-      Post.blueprint { }
-      post = Post.make
-      post.should be_a(Post)
+      DM::Post.blueprint { }
+      post = DM::Post.make
+      post.should be_a(DM::Post)
       post.should be_new
     end
   end
   
   context "make!" do
     it "should make and save objects" do
-      Post.blueprint { }
-      post = Post.make!
-      post.should be_a(Post)
+      DM::Post.blueprint { }
+      post = DM::Post.make!
+      post.should be_a(DM::Post)
       post.should_not be_new
     end
 
     it "should raise an exception for an invalid object" do
-      User.blueprint { }
-      lambda {
-        User.make!(:username => "")
-      }.should raise_error(DataMapper::SaveFailureError)
+      DM::User.blueprint { }
+      expect { DM::User.make!(:username => "") }.to
+        raise_error(DataMapper::SaveFailureError)
     end
   end
   
   context "associations support" do
     it "should handle belongs_to associations" do
-      User.blueprint do
+      DM::User.blueprint do
         username { "user_#{sn}" }
       end
-      Post.blueprint do
+      DM::Post.blueprint do
         author
       end
-      post = Post.make!
-      post.should be_a(Post)
+      post = DM::Post.make!
+      post.should be_a(DM::Post)
       post.should_not be_new
-      post.author.should be_a(User)
+      post.author.should be_a(DM::User)
       post.author.should_not be_new
     end
     
     it "should handle has_many associations" do
-      Post.blueprint do
+      DM::Post.blueprint do
         comments(3)
       end
-      Comment.blueprint { }
-      post = Post.make!
-      post.should be_a(Post)
+      DM::Comment.blueprint { }
+      post = DM::Post.make!
+      post.should be_a(DM::Post)
       post.should_not be_new
       post.should have(3).comments
       post.comments.each do |comment|
-        comment.should be_a(Comment)
+        comment.should be_a(DM::Comment)
         comment.should_not be_new
       end
     end
     
     it "should handle habtm associations" do
-      Post.blueprint do
+      DM::Post.blueprint do
         tags(3)
       end
-      Tag.blueprint do
+      DM::Tag.blueprint do
         name { "tag_#{sn}" }
       end
-      post = Post.make!
-      post.should be_a(Post)
+      post = DM::Post.make!
+      post.should be_a(DM::Post)
       post.should_not be_new
       post.should have(3).tags
       post.tags.each do |tag|
-        tag.should be_a(Tag)
+        tag.should be_a(DM::Tag)
         tag.should_not be_new
       end
     end
     
     it "should handle overriding associations" do
-      User.blueprint do
+      DM::User.blueprint do
         username { "user_#{sn}" }
       end
-      Post.blueprint do
-        author { DataMapperEnvironment::User.make!(:username => "post_author_#{sn}") }
+      DM::Post.blueprint do
+        author { DM::User.make!(:username => "post_author_#{sn}") }
       end
-      post = Post.make!
-      post.should be_a(Post)
+      post = DM::Post.make!
+      post.should be_a(DM::Post)
       post.should_not be_new
-      post.author.should be_a(User)
+      post.author.should be_a(DM::User)
       post.author.should_not be_new
       post.author.username.should =~ /^post_author_\d+$/
     end
@@ -98,10 +97,8 @@ describe Machinist::DataMapper do
   
   context "error handling" do
     it "should raise an exception for an attribute with no value" do
-      User.blueprint { username }
-      lambda {
-        User.make
-      }.should raise_error(ArgumentError)
+      DM::User.blueprint { username }
+      expect { DM::User.make }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/support/active_record_environment.rb
+++ b/spec/support/active_record_environment.rb
@@ -34,29 +34,29 @@ ActiveRecord::Schema.define(:version => 0) do
   end
 end
 
-class User < ActiveRecord::Base
-  validates_presence_of :username
-  validates_uniqueness_of :username
-end
-
-class Post < ActiveRecord::Base
-  has_many :comments
-  belongs_to :author, :class_name => "User"
-  has_and_belongs_to_many :tags
-end
-
-class Comment < ActiveRecord::Base
-  belongs_to :post
-end
-
-class Tag < ActiveRecord::Base
-  has_and_belongs_to_many :posts
-end
-
 module ActiveRecordEnvironment
 
-  def empty_database!
-    [User, Post, Comment].each do |klass|
+  class User < ActiveRecord::Base
+    validates_presence_of :username
+    validates_uniqueness_of :username
+  end
+
+  class Post < ActiveRecord::Base
+    has_many :comments
+    belongs_to :author, :class_name => "User"
+    has_and_belongs_to_many :tags
+  end
+
+  class Comment < ActiveRecord::Base
+    belongs_to :post
+  end
+
+  class Tag < ActiveRecord::Base
+    has_and_belongs_to_many :posts
+  end
+
+  def self.empty_database!
+    [User, Post, Comment, Tag].each do |klass|
       klass.delete_all
       klass.clear_blueprints!
     end

--- a/spec/support/data_mapper_environment.rb
+++ b/spec/support/data_mapper_environment.rb
@@ -1,0 +1,56 @@
+require 'dm-core'
+require 'dm-validations'
+require 'machinist/data_mapper'
+
+DataMapper.setup(:default, :adapter => :in_memory)
+
+module DataMapperEnvironment
+  class User
+    include DataMapper::Resource
+
+    property :id,       Serial
+    property :username, String
+
+    validates_presence_of :username
+    validates_uniqueness_of :username
+  end
+
+  class Post
+    include DataMapper::Resource
+
+    property :id,       Serial
+    property :title,    String
+    property :body,     Text
+
+    belongs_to :author, 'User', :required => false
+    has n, :comments
+    has n, :tags, :through => Resource
+  end
+
+  class Comment
+    include DataMapper::Resource
+
+    property :id,       Serial
+    property :body,     Text
+
+    belongs_to :post, :required => false
+  end
+
+  class Tag
+    include DataMapper::Resource
+
+    property :id,       Serial
+    property :name,     String
+
+    has n, :posts, :through => Resource
+  end
+
+  def purge_models!
+    User.destroy
+    Post.destroy
+    Comment.destroy
+    Tag.destroy
+  end
+end
+
+DataMapper.finalize

--- a/spec/support/data_mapper_environment.rb
+++ b/spec/support/data_mapper_environment.rb
@@ -10,10 +10,7 @@ module DataMapperEnvironment
     include DataMapper::Resource
 
     property :id,       Serial
-    property :username, String
-
-    validates_presence_of :username
-    validates_uniqueness_of :username
+    property :username, String, :required => true, :unique => true
   end
 
   class Post

--- a/spec/support/data_mapper_environment.rb
+++ b/spec/support/data_mapper_environment.rb
@@ -1,8 +1,9 @@
 require 'dm-core'
 require 'dm-validations'
+require 'dm-migrations'
 require 'machinist/data_mapper'
 
-DataMapper.setup(:default, :adapter => :in_memory)
+DataMapper.setup(:default, 'mysql://localhost/machinist?user=root&password=')
 
 module DataMapperEnvironment
   class User
@@ -54,3 +55,4 @@ module DataMapperEnvironment
 end
 
 DataMapper.finalize
+DataMapper.auto_migrate!

--- a/spec/support/data_mapper_environment.rb
+++ b/spec/support/data_mapper_environment.rb
@@ -43,11 +43,11 @@ module DataMapperEnvironment
     has n, :posts, :through => Resource
   end
 
-  def purge_models!
-    User.destroy
-    Post.destroy
-    Comment.destroy
-    Tag.destroy
+  def self.empty_database!
+    [User, Post, Comment, Tag].each do |model|
+      model.destroy
+      model.clear_blueprints!
+    end
   end
 end
 


### PR DESCRIPTION
100% of specs passing.  Implementation clean/straightforward and not magic.  In terms of what I had to do to make it work.  Basically nothing.  Just "translate" the AR stuff to DM code.  Including the specs, which were what drove the implementation.

I had to namespace the fixtures under `module DataMapperEnvironment` in order to stop the specs failing due the fact classes `User`, `Post` etc already exist at the top-level namespace.

Hopefully you can merge this into the main project.
