### PR TITLE
Travis-CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+rvm:
+  - 1.9.3
+  - 1.9.2
+env:
+  - RAILS_VERSION=3.0.10
+  - RAILS_VERSION=3.1.0
+branches:
+  only: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 rvm:
   - 1.9.3
   - 1.9.2
+  - 1.8.7
 env:
   - RAILS_VERSION=3.0.10
   - RAILS_VERSION=3.1.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source "http://rubygems.org"
 gemspec
+
+gem 'activerecord', ENV['RAILS_VERSION'] || "3.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,21 +6,24 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.0.9)
-      activesupport (= 3.0.9)
-      builder (~> 2.1.2)
-      i18n (~> 0.5.0)
-    activerecord (3.0.9)
-      activemodel (= 3.0.9)
-      activesupport (= 3.0.9)
-      arel (~> 2.0.10)
-      tzinfo (~> 0.3.23)
-    activesupport (3.0.9)
-    arel (2.0.10)
-    builder (2.1.2)
+    activemodel (3.1.0)
+      activesupport (= 3.1.0)
+      bcrypt-ruby (~> 3.0.0)
+      builder (~> 3.0.0)
+      i18n (~> 0.6)
+    activerecord (3.1.0)
+      activemodel (= 3.1.0)
+      activesupport (= 3.1.0)
+      arel (~> 2.2.1)
+      tzinfo (~> 0.3.29)
+    activesupport (3.1.0)
+      multi_json (~> 1.0)
+    arel (2.2.1)
+    bcrypt-ruby (3.0.1)
+    builder (3.0.0)
     diff-lcs (1.1.2)
-    i18n (0.5.0)
-    mysql (2.8.1)
+    i18n (0.6.0)
+    multi_json (1.0.3)
     rake (0.9.2)
     rcov (0.9.9)
     rdoc (3.6.1)
@@ -32,16 +35,17 @@ GEM
     rspec-expectations (2.6.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.6.0)
-    tzinfo (0.3.28)
+    sqlite3 (1.3.4)
+    tzinfo (0.3.29)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord
+  activerecord (= 3.1.0)
   machinist!
-  mysql
   rake
   rcov
   rdoc
   rspec
+  sqlite3

--- a/README.markdown
+++ b/README.markdown
@@ -2,6 +2,9 @@
 
 *Fixtures aren't fun. Machinist is.*
 
+[![Build Status](https://secure.travis-ci.org/hosh/machinist.png)](http://travis-ci.org/hosh/machinist)
+
+
 Machinist 2 is **still in beta**!
 
 If you're using Rails 3, you'll want to give Machinist 2 a go, but be aware

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ RSpec::Core::RakeTask.new(:rcov) do |spec|
 end
 
 desc 'Run the specs.'
-task :default => :rcov
+task :default => :spec
 
 
 RDoc::Task.new(:rdoc) do |rdoc|

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ RSpec::Core::RakeTask.new(:rcov) do |spec|
 end
 
 desc 'Run the specs.'
-task :default => :spec
+task :default => :rcov
 
 
 RDoc::Task.new(:rdoc) do |rdoc|

--- a/lib/machinist/active_resource.rb
+++ b/lib/machinist/active_resource.rb
@@ -1,0 +1,14 @@
+require 'active_resource'
+require 'machinist'
+require 'machinist/active_resource/blueprint'
+require 'machinist/active_record/lathe'
+
+module ActiveResource #:nodoc:
+  class Base #:nodoc:
+    extend Machinist::Machinable
+
+    def self.blueprint_class
+      Machinist::ActiveResource::Blueprint
+    end
+  end
+end

--- a/lib/machinist/active_resource/blueprint.rb
+++ b/lib/machinist/active_resource/blueprint.rb
@@ -1,0 +1,16 @@
+module Machinist::ActiveResource
+  class Blueprint < Machinist::Blueprint
+
+    # Make and save an object.
+    def make!(attributes = {})
+      object = make(attributes)
+      object.save!
+      object.reload
+    end
+
+    def lathe_class #:nodoc:
+      Machinist::ActiveRecord::Lathe
+    end
+
+  end
+end

--- a/machinist.gemspec
+++ b/machinist.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "activerecord"
-  s.add_development_dependency "mysql"
+  s.add_development_dependency "sqlite3"
   s.add_development_dependency "rake"
   s.add_development_dependency "rcov"
   s.add_development_dependency "rspec"

--- a/spec/support/active_record_environment.rb
+++ b/spec/support/active_record_environment.rb
@@ -2,10 +2,9 @@ require 'active_record'
 require 'machinist/active_record'
 
 ActiveRecord::Base.establish_connection(
-  :adapter  => "mysql",
-  :database => "machinist",
-  :username => "root",
-  :password => ""
+  :adapter  => "sqlite3",
+  :database => ":memory:",
+  :timeout  => 500,
 )
 
 ActiveRecord::Schema.define(:version => 0) do

--- a/spec/support/active_record_environment.rb
+++ b/spec/support/active_record_environment.rb
@@ -4,7 +4,7 @@ require 'machinist/active_record'
 ActiveRecord::Base.establish_connection(
   :adapter  => "sqlite3",
   :database => ":memory:",
-  :timeout  => 500,
+  :timeout  => 500
 )
 
 ActiveRecord::Schema.define(:version => 0) do


### PR DESCRIPTION
I've added Travis-CI support. It will test all combinations of:

Ruby 1.8.7, 1.9.2, 1.9.3
Rails 3.0.10, 3.1.0

It defaults to 3.1.0.

Let me know if anything needs changing.
