### PR TITLE
Make Rails 3 load Machinist as the fixture_replacement

### DIFF
--- a/lib/machinist.rb
+++ b/lib/machinist.rb
@@ -2,4 +2,4 @@ require 'machinist/blueprint'
 require 'machinist/exceptions'
 require 'machinist/lathe'
 require 'machinist/machinable'
-
+require 'machinist/railtie' if defined?(Rails::Railtie)

--- a/lib/machinist/railtie.rb
+++ b/lib/machinist/railtie.rb
@@ -1,0 +1,5 @@
+module Machinist
+  class Railtie < ::Rails::Railtie
+    config.generators.fixture_replacement :machinist
+  end
+end


### PR DESCRIPTION
This just means that Rails 3 will automatically know to use Machinist as the fixture replacement as long as you put "machinist" in your Gemfile.
