### PR TITLE
1.0 maintenance: foreign_key instead of primary_key_name for Rails 3.1

### DIFF
--- a/lib/machinist/active_record.rb
+++ b/lib/machinist/active_record.rb
@@ -33,7 +33,11 @@ module Machinist
       lathe.assigned_attributes.each_pair do |attribute, value|
         association = lathe.object.class.reflect_on_association(attribute)
         if association && association.macro == :belongs_to && !value.nil?
-          attributes[association.primary_key_name.to_sym] = value.id
+          if association.respond_to?(:foreign_key) # For Rails 3.1 and above
+            attributes[association.foreign_key.to_sym] = value.id
+          else
+            attributes[association.primary_key_name.to_sym] = value.id
+          end
         else
           attributes[attribute] = value
         end


### PR DESCRIPTION
Uses foreign_key instead of primary_key_name for Rails 3.1 and above. DEPRECATION WARNING: primary_key_name is deprecated and will be removed from Rails 3.2 (use foreign_key instead)
