### PR TITLE
Error messages for generator

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -62,7 +62,11 @@ In your app's `Gemfile`, in the `group :test` section, add:
 Then run:
 
     bundle
-    rails generate machinist:install
+    rails generate machinist:install 
+
+Or (if you are using rspec)
+    bundle
+    rails generate machinist:install -t rspec
 
 If you want Machinist to automatically add a blueprint to your blueprints file
 whenever you generate a model, add the following to your `config/application.rb`

--- a/lib/generators/machinist/install/install_generator.rb
+++ b/lib/generators/machinist/install/install_generator.rb
@@ -2,22 +2,27 @@ module Machinist
   module Generators #:nodoc:
     class InstallGenerator < Rails::Generators::Base #:nodoc:
       source_root File.expand_path('../templates', __FILE__)
-
-      class_option :test_framework, :type => :string, :aliases => "-t", :desc => "Test framework to use Machinist with"
-      class_option :cucumber, :type => :boolean, :desc => "Set up access to Machinist from Cucumber"
+      class_option :test_framework, :type => :string, :default => 'test_unit', :aliases => "-t", :desc => "Test framework to use Machinist with"
+      class_option :cucumber, :type => :boolean, :default => false, :desc => "Set up access to Machinist from Cucumber"
 
       def blueprints_file
         if rspec?
           copy_file "blueprints.rb", "spec/support/blueprints.rb" 
-        else
+        elsif test_unit?
           copy_file "blueprints.rb", "test/blueprints.rb"
+        else
+          say_status(:error, "No test framework found. Please specify either 'rspec' or 'test_unit' with the -t option.", :red)
         end
       end
-
+      
       def test_helper
-        if test_unit?
-          inject_into_file("test/test_helper.rb", :after => "require 'rails/test_help'\n") do
-            "require File.expand_path(File.dirname(__FILE__) + '/blueprints')\n"
+        if test_unit? 
+          if File.exist?("test/test_helper.rb")
+            inject_into_file("test/test_helper.rb", :after => "require 'rails/test_help'\n") do
+              "require File.expand_path(File.dirname(__FILE__) + '/blueprints')\n"
+            end
+          else
+            say_status(:warning, "Unable to modify the test_helper file. It does not exist.", :red)
           end
         end
       end
@@ -31,11 +36,11 @@ module Machinist
     private
 
       def rspec?
-        options[:test_framework].to_sym == :rspec
+        options[:test_framework] and options[:test_framework].to_sym == :rspec 
       end
 
-      def test_unit?
-        options[:test_framework].to_sym == :test_unit
+      def test_unit?        
+        options[:test_framework] and options[:test_framework].to_sym == :test_unit
       end
 
       def cucumber?


### PR DESCRIPTION
Was just adding machinist into an older application - and got this error:

 /home/dan/.rvm/gems/ruby-1.9.3-p0@clause/gems/machinist-2.0/lib/generators/machinist/install/install_generator.rb:34:in `rspec?': undefined method`to_sym' for nil:NilClass (NoMethodError)

of course, it's just a matter of adding a "-t rspec" for the generator, but after having looked into it, I figured I'd add some error messages to make this easier for the next guy.
