### PR TITLE
Added ability to set a base serial number

### DIFF
--- a/lib/machinist/blueprint.rb
+++ b/lib/machinist/blueprint.rb
@@ -66,13 +66,21 @@ module Machinist
       if parent_blueprint
         parent_blueprint.new_serial_number
       else
-        @serial_number ||= 0
+        @serial_number ||= self.class.serial_number_base
         @serial_number += 1
         sprintf("%04d", @serial_number)
       end
     end
 
-  private
+    def self.serial_number_base
+      @serial_number_base || 0
+    end
+
+    def self.serial_number_base=(value)
+      @serial_number_base = value
+    end
+
+    private
 
     def find_blueprint_in_superclass_chain(klass)
       until has_blueprint?(klass) || klass.nil?

--- a/lib/machinist/blueprint.rb
+++ b/lib/machinist/blueprint.rb
@@ -2,6 +2,7 @@ module Machinist
 
   # A Blueprint defines a method of constructing objects of a particular class.
   class Blueprint
+    @@serial_number_base = 0
 
     # Construct a blueprint for the given +klass+.
     #
@@ -73,11 +74,11 @@ module Machinist
     end
 
     def self.serial_number_base
-      @serial_number_base || 0
+      @@serial_number_base || 0
     end
 
     def self.serial_number_base=(value)
-      @serial_number_base = value
+      @@serial_number_base = value || 0
     end
 
     private

--- a/spec/active_record_spec.rb
+++ b/spec/active_record_spec.rb
@@ -94,6 +94,19 @@ describe Machinist::ActiveRecord do
       post.author.should_not be_new_record
       post.author.username.should =~ /^post_author_\d+$/
     end
+
+    it "handles serial number base override" do
+      User.blueprint do
+        username { "user_#{sn}" }
+      end
+      Machinist::Blueprint.serial_number_base = 10000
+
+      User.make!.username.should == "user_10001"
+      User.make!.username.should == "user_10002"
+      Machinist::Blueprint.serial_number_base = 500
+      User.make!.username.should == "user_10003"
+      Machinist::Blueprint.serial_number_base = nil
+    end
   end
 
   context "error handling" do

--- a/spec/blueprint_spec.rb
+++ b/spec/blueprint_spec.rb
@@ -43,6 +43,16 @@ describe Machinist::Blueprint do
     blueprint.make.name.should == "Fred 0002"
   end
 
+  it "allows serial number start value to be overridden" do
+    Machinist::Blueprint.serial_number_base = 1000
+    blueprint = Machinist::Blueprint.new(OpenStruct) do
+      name { "Fred #{sn}" }
+    end
+    blueprint.make.name.should == "Fred 1001"
+    blueprint.make.name.should == "Fred 1002"
+    Machinist::Blueprint.serial_number_base = nil
+  end
+
   it "provides access to the object being constructed within the blueprint" do
     blueprint = Machinist::Blueprint.new(OpenStruct) do
       title { "Test" }


### PR DESCRIPTION
This is for using machinist alongside pre-existing fixtures, for example with the gem FixtureBuilder https://github.com/rdy/fixture_builder.

In this case, fixtures (including serial numbers) may be cached and re-used during multiple test runs.  Blueprinted models created during the run where cached fixtures are used should not have the same serial numbers as those stored in the fixture files.  A global base serial number value can resolve this.
