### PR TITLE
Making Machinist run on jruby, too

### DIFF
--- a/machinist.gemspec
+++ b/machinist.gemspec
@@ -19,7 +19,14 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "activerecord"
-  s.add_development_dependency "mysql"
+
+  if RUBY_PLATFORM == "java"
+    s.add_development_dependency "activerecord-jdbc-adapter"
+    s.add_development_dependency "activerecord-jdbcmysql-adapter"
+  else
+    s.add_development_dependency "mysql"
+  end
+
   s.add_development_dependency "rake"
   s.add_development_dependency "rcov"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
Hi, here's a rather small pull request that adds jruby support.

Tests are passing :) on both platforms

```
jruby-1.6.5 :010 > RUBY_PLATFORM
 => "java"
➜  machinist git:(master) ✗ bundle install
Using rake (0.9.2) 
Using activesupport (3.0.9) 
Using builder (2.1.2) 
Using i18n (0.5.0) 
Using activemodel (3.0.9) 
Using arel (2.0.10) 
Using tzinfo (0.3.28) 
Using activerecord (3.0.9) 
Using activerecord-jdbc-adapter (1.2.2) 
Using jdbc-mysql (5.1.13) 
Using activerecord-jdbcmysql-adapter (1.2.2) 
Using diff-lcs (1.1.2) 
Using machinist (2.0) from source at . 
Using rcov (0.9.9) 
Using rdoc (3.6.1) 
Using rspec-core (2.6.4) 
Using rspec-expectations (2.6.0) 
Using rspec-mocks (2.6.0) 
Using rspec (2.6.0) 
Using bundler (1.2.0.pre.1) 
Your bundle is complete! Use `bundle show [gemname]` to see where a bundled gem is installed.
➜  machinist git:(master) ✗ bundle exec rspec spec     
-- create_table(:users, {:force=>true})
   -> 0.6490s
   -> 0 rows
-- create_table(:posts, {:force=>true})
   -> 0.0180s
   -> 0 rows
-- create_table(:comments, {:force=>true})
   -> 0.0190s
   -> 0 rows
-- create_table(:tags, {:force=>true})
   -> 0.0170s
   -> 0 rows
-- create_table(:posts_tags, {:id=>false, :force=>true})
   -> 0.0180s
   -> 0 rows
-- initialize_schema_migrations_table()
   -> 0.0020s
-- assume_migrated_upto_version(0, "db/migrate")
   -> 0.0020s
..............................

Finished in 0.656 seconds
30 examples, 0 failures
```

If you don't mind/want to, I could add .travis.yml with all supported rubies. What do you think?
