### PR TITLE
Build immutable classes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -201,6 +201,28 @@ You can blueprint the Post class just like anything else:
 
 And `Post.make` will construct a new Post.
 
+### Immutable Objects
+
+You don't need to expose writer methods for the attributes you wish to leverage in the blueprint.
+
+For example:
+
+    class Post
+      extend Machinist::Machinable
+
+      attr_reader :title
+      attr_reader :body
+    end
+
+The blueprint above will still work:
+
+    Post.blueprint do
+      title { "A title!" }
+      body  { "A body!" }
+    end
+
+And `Post.make` will still construct a new Post.
+
 
 ### Other Tricks
 

--- a/lib/machinist/lathe.rb
+++ b/lib/machinist/lathe.rb
@@ -53,7 +53,11 @@ module Machinist
     
     def assign_attribute(key, value) #:nodoc:
       @assigned_attributes[key.to_sym] = value
-      @object.send("#{key}=", value)
+      begin
+        @object.send("#{key}=", value)
+      rescue
+        @object.instance_variable_set("@#{key}", value)
+      end
     end
   
     def attribute_assigned?(key) #:nodoc:

--- a/spec/machinable_spec.rb
+++ b/spec/machinable_spec.rb
@@ -10,6 +10,11 @@ module MachinableSpecs
     extend Machinist::Machinable
     attr_accessor :post, :title
   end
+
+  class Immutable
+    extend Machinist::Machinable
+    attr_reader :name
+  end
 end
 
 describe Machinist::Machinable do
@@ -70,6 +75,16 @@ describe Machinist::Machinable do
     post.comments.each do |comment|
       comment.should be_a(MachinableSpecs::Comment)
     end
+  end
+
+  it "supports immutable classes" do
+    MachinableSpecs::Immutable.blueprint do
+      name { "Mr. Immutable" }
+    end
+
+    post = MachinableSpecs::Immutable.make
+    post.should be_a(MachinableSpecs::Immutable)
+    post.name.should == "Mr. Immutable"
   end
 
   it "fails without a blueprint" do


### PR DESCRIPTION
Immutable classes are my friend, but machinist doesn't seem to like them. This patch fixes that.

The `Lathe` class has traditionally called the `#{key}=` method on the object in question to set a given value, but my immutable friends don't have that method.

Because `attr_reader` uses instance variables under the hood, machinist can set the instance variable in question to the given value and all will be happy.

I had to use a `begin` block in `Lathe` because the `OpenStruct` instances used by other specs in `machinable_spec.rb` doesn't support `#respond_to?`. If this was changed the patch could be refactored to use `if @object.respond_to?("#{key}=")`.
