### PR TITLE
Update Ruby examples in README with codefencing

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,35 +18,39 @@ for the attributes you don't care about, and constructs any necessary
 associated objects, leaving you to specify only the fields you care about in
 your test. For example:
 
-    describe Comment, "without_spam scope" do
-      it "doesn't include spam" do
-        # This will make a Comment, a Post, and a User (the author of the
-        # Post), generate values for all their attributes, and save them:
-        spam = Comment.make!(:spam => true)
+```ruby
+describe Comment, "without_spam scope" do
+  it "doesn't include spam" do
+    # This will make a Comment, a Post, and a User (the author of the
+    # Post), generate values for all their attributes, and save them:
+    spam = Comment.make!(:spam => true)
 
-        Comment.without_spam.should_not include(spam)
-      end
-    end
+    Comment.without_spam.should_not include(spam)
+  end
+end
+```
 
 You tell Machinist how to do this with blueprints:
 
-    require 'machinist/active_record'
+```ruby
+require 'machinist/active_record'
 
-    User.blueprint do
-      username { "user#{sn}" }  # Each user gets a unique serial number.
-    end
+User.blueprint do
+  username { "user#{sn}" }  # Each user gets a unique serial number.
+end
 
-    Post.blueprint do
-      author
-      title  { "Post #{sn}" }
-      body   { "Lorem ipsum..." }
-    end
+Post.blueprint do
+  author
+  title  { "Post #{sn}" }
+  body   { "Lorem ipsum..." }
+end
 
-    Comment.blueprint do
-      post
-      email { "commenter#{sn}@example.com" }
-      body  { "Lorem ipsum..." }
-    end
+Comment.blueprint do
+  post
+  email { "commenter#{sn}@example.com" }
+  body  { "Lorem ipsum..." }
+end
+```
 
 
 ## Installation
@@ -59,20 +63,26 @@ See [the wiki](http://wiki.github.com/notahat/machinist/machinist-2).
 
 In your app's `Gemfile`, in the `group :test` section, add:
 
-    gem 'machinist', '>= 2.0.0.beta2'
+```ruby
+gem 'machinist', '>= 2.0.0.beta2'
+```
 
 Then run:
 
-    bundle
-    rails generate machinist:install
+```
+bundle
+rails generate machinist:install
+```
 
 If you want Machinist to automatically add a blueprint to your blueprints file
 whenever you generate a model, add the following to your `config/application.rb`
 inside the Application class:
 
-    config.generators do |g|
-      g.fixture_replacement :machinist
-    end
+```ruby
+config.generators do |g|
+  g.fixture_replacement :machinist
+end
+```
 
 ### Rails 2
 
@@ -89,14 +99,18 @@ just the attributes that are important for the test.
 
 A simple blueprint might look like this:
 
-    Post.blueprint do
-      title  { "A Post" }
-      body   { "Lorem ipsum..." }
-    end
+```ruby
+Post.blueprint do
+  title  { "A Post" }
+  body   { "Lorem ipsum..." }
+end
+```
 
 You can then construct a Post from this blueprint with:
 
-    Post.make!
+```ruby
+Post.make!
+```
 
 When you call `make!`, Machinist calls `Post.new`, then runs through the
 attributes in your blueprint, calling the block for each attribute to generate
@@ -105,7 +119,9 @@ Post can't be saved.)
 
 You can override values defined in the blueprint by passing a hash to make:
 
-    Post.make!(:title => "A Specific Title")
+```ruby
+Post.make!(:title => "A Specific Title")
+```
 
 If you want to generate an object without saving it to the database, replace
 `make!` with `make`.
@@ -116,18 +132,22 @@ If you want to generate an object without saving it to the database, replace
 For attributes that need to be unique, you can call the `sn` method from
 within the attribute block to get a unique serial number for the object.
 
-    User.blueprint do
-      username { "user-#{sn}" }
-    end
+```ruby
+User.blueprint do
+  username { "user-#{sn}" }
+end
+```
 
 
 ### Associations
 
 If your object needs associated objects, you can generate them like this:
 
-    Comment.blueprint do
-      post { Post.make }
-    end
+```ruby
+Comment.blueprint do
+  post { Post.make }
+end
+```
 
 Calling `Comment.make!` will construct a Comment and its associated Post, and
 save both.
@@ -135,23 +155,29 @@ save both.
 Machinist is smart enough to look at the association and work out what sort of
 object it needs to create, so you can shorten the above blueprint to:
 
-    Comment.blueprint do
-      post
-    end
+```ruby
+Comment.blueprint do
+  post
+end
+```
 
 If you want to override the value for post when constructing the comment, you
 can do this:
 
-    post = Post.make(:title => "A particular title)
-    comment = Comment.make(:post => post)
+```ruby
+post = Post.make(:title => "A particular title")
+comment = Comment.make(:post => post)
+```
 
 
 For `has_many` and `has_and_belongs_to_many` associations, you can create
 multiple associated objects like this:
 
-    Post.blueprint do
-      comments(3)  # Makes 3 comments.
-    end
+```ruby
+Post.blueprint do
+  comments(3)  # Makes 3 comments.
+end
+```
 
 
 ### Named Blueprints
@@ -159,19 +185,23 @@ multiple associated objects like this:
 Named blueprints let you define variations on an object. For example, suppose
 some of your Users are administrators:
 
-    User.blueprint do
-      name  { "User #{sn}" }
-      email { "user-#{sn}@example.com" }
-    end
+```ruby
+User.blueprint do
+  name  { "User #{sn}" }
+  email { "user-#{sn}@example.com" }
+end
 
-    User.blueprint(:admin) do
-      name  { "Admin User #{sn}" }
-      admin { true }
-    end
+User.blueprint(:admin) do
+  name  { "Admin User #{sn}" }
+  admin { true }
+end
+```
 
 Calling:
 
-    User.make!(:admin)
+```ruby
+User.make!(:admin)
+```
 
 will use the `:admin` blueprint.
 
@@ -187,19 +217,23 @@ even if the default blueprint is empty.
 
 Machinist also works with plain old Ruby objects. Let's say you have a class like:
 
-    class Post
-      extend Machinist::Machinable
+```ruby
+class Post
+  extend Machinist::Machinable
 
-      attr_accessor :title
-      attr_accessor :body
-    end
+  attr_accessor :title
+  attr_accessor :body
+end
+```
 
 You can blueprint the Post class just like anything else:
 
-    Post.blueprint do
-      title { "A title!" }
-      body  { "A body!" }
-    end
+```ruby
+Post.blueprint do
+  title { "A title!" }
+  body  { "A body!" }
+end
+```
 
 And `Post.make` will construct a new Post.
 
@@ -208,10 +242,12 @@ And `Post.make` will construct a new Post.
 
 You can refer to already assigned attributes when constructing a new attribute:
 
-    Post.blueprint do
-      author { "Author #{sn}" }
-      body   { "Post by #{object.author}" }
-    end
+```ruby
+Post.blueprint do
+  author { "Author #{sn}" }
+  body   { "Post by #{object.author}" }
+end
+```
 
 
 ### More Details
@@ -293,4 +329,3 @@ Thanks to Thoughtbot's [Factory
 Girl](http://github.com/thoughtbot/factory_girl/tree/master). Machinist was
 written because I loved the idea behind Factory Girl, but I thought the
 philosophy wasn't quite right, and I hated the syntax.
-


### PR DESCRIPTION
Using codefencing in the README we can update the examples from plain text to Ruby examples and it gives it a little more :sparkles: 

Before:

![image](https://f.cloud.github.com/assets/79995/1111417/27f5b7ea-19ab-11e3-8a90-3cb5e93dc359.png)

After:

![image](https://f.cloud.github.com/assets/79995/1111415/13772f56-19ab-11e3-9361-ff29da15f239.png)
