### PR TITLE
Add license to gemspec

### DIFF
--- a/machinist.gemspec
+++ b/machinist.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.email    = ["pete@notahat.com"]
   s.homepage = "http://github.com/notahat/machinist"
   s.summary  = "Fixtures aren't fun. Machinist is."
+  s.license  = "MIT"
 
   s.rubyforge_project = "machinist"
 


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.
