### PR TITLE
Fixnum & Integer unification for Ruby 2.4 compatibility

### DIFF
--- a/lib/machinist/lathe.rb
+++ b/lib/machinist/lathe.rb
@@ -38,7 +38,7 @@ module Machinist
   protected
 
     def make_attribute(attribute, args, &block) #:nodoc:
-      count = args.shift if args.first.is_a?(Fixnum)
+      count = args.shift if args.first.is_a?(0.class)
       if count
         Array.new(count) { make_one_value(attribute, args, &block) }
       else

--- a/lib/machinist/machinable.rb
+++ b/lib/machinist/machinable.rb
@@ -75,7 +75,7 @@ module Machinist
     # construct multiple objects.
     def decode_args_to_make(*args) #:nodoc:
       shift_arg = lambda {|klass| args.shift if args.first.is_a?(klass) }
-      count      = shift_arg[Fixnum]
+      count      = shift_arg[0.class]
       name       = shift_arg[Symbol] || :master
       attributes = shift_arg[Hash]   || {}
       raise ArgumentError.new("Couldn't understand arguments") unless args.empty?


### PR DESCRIPTION
This removes the deprecation warning

`warning: constant ::Fixnum is deprecated`