### PR TITLE
Update to include support for MRI 2.4

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,6 +11,8 @@ If you want Machinist 1, [go here](http://github.com/notahat/machinist/tree/1.0-
 
 ## Introduction
 
+*Note: Machinist isn't under active development. See the Status section below for more info.*
+
 Machinist makes it easy to create objects for use in tests. It generates data
 for the attributes you don't care about, and constructs any necessary
 associated objects, leaving you to specify only the fields you care about in
@@ -250,10 +252,13 @@ If you want to submit a patch:
 
 ## Status
 
-In active use in a number of large Rails 2 apps.
+In active use in a number of large Rails 2 and 3 apps.
 
 Development is sporadic at best, as I find myself with less and less need for
-factories in tests. If anybody wants to take over maintenance, let me know.
+factories in tests. See Bo Jeanes'
+[excellent article on the topic](http://bjeanes.com/2012/02/factories-breed-complexity).
+
+If anybody wants to take over maintenance, let me know.
 
 
 ## Contributors

--- a/lib/machinist/lathe.rb
+++ b/lib/machinist/lathe.rb
@@ -38,7 +38,7 @@ module Machinist
   protected
 
     def make_attribute(attribute, args, &block) #:nodoc:
-      count = args.shift if args.first.is_a?(Fixnum)
+      count = args.shift if args.first.is_a?(0.class)
       if count
         Array.new(count) { make_one_value(attribute, args, &block) }
       else

--- a/lib/machinist/machinable.rb
+++ b/lib/machinist/machinable.rb
@@ -75,7 +75,7 @@ module Machinist
     # construct multiple objects.
     def decode_args_to_make(*args) #:nodoc:
       shift_arg = lambda {|klass| args.shift if args.first.is_a?(klass) }
-      count      = shift_arg[Fixnum]
+      count      = shift_arg[0.class]
       name       = shift_arg[Symbol] || :master
       attributes = shift_arg[Hash]   || {}
       raise ArgumentError.new("Couldn't understand arguments") unless args.empty?


### PR DESCRIPTION
[MRI 2.4 unified Fixnum + Bignum](https://bugs.ruby-lang.org/issues/12005). To prevent throwing of deprecation
notices, we need to update the library to account for Bignum, Fixnum and
Integer since they are all possible outcomes.