### PR TITLE
use Dir.glob instead of 'git ls-files'

### DIFF
--- a/machinist.gemspec
+++ b/machinist.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "machinist"
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files         = Dir.glob("lib/**/*") 
+  s.test_files    = Dir.glob("{test,spec,features}/**/*") 
+  s.executables   = Dir.glob("bin/*").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.add_development_dependency "activerecord"


### PR DESCRIPTION
In certain environments git might not be present, or in the case of a vendor'd version of this gem git will complain about not being in a repository. 

See https://github.com/jfelchner/ruby-progressbar/commit/1f80f5c2f3159dc1c5ae9d77ffa4904aa2c373ed for where this has been done.